### PR TITLE
Fixes PHP 8.3 deprecation notice

### DIFF
--- a/src/DateRangeFilter.php
+++ b/src/DateRangeFilter.php
@@ -16,6 +16,8 @@ class DateRangeFilter extends Filter
      */
     public $component = 'nova-date-range-filter';
 
+    protected string $column;
+
     /**
      * Create a new filter instance.
      *


### PR DESCRIPTION
Fixes this deprecation warning:
```
Creation of dynamic property Marshmallow\Filters\DateRangeFilter::$column is deprecated in /var/www/vendor/marshmallow/nova-date-range-filter/src/DateRangeFilter.php on line 29
```